### PR TITLE
Fix access log location and error in port mapping

### DIFF
--- a/kruiser.yaml
+++ b/kruiser.yaml
@@ -19,7 +19,8 @@ data:
         server {
           listen 8080 http2;
     
-          access_log /tmp/grpc.log;
+          access_log /dev/stdout;
+          error_log /dev/stderr warn;
 
           location / {
            grpc_pass grpc://127.0.0.1:9000;
@@ -77,7 +78,7 @@ spec:
   ports:
   - name: proxy
     port: 8080
-    targetPort: 80
+    targetPort: 8080
   - name: grpc
     port: 9000
     targetPort: 9000


### PR DESCRIPTION
```
aledbf@me:~$ kubectl get svc kruiser
NAME      TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                         AGE
kruiser   NodePort   10.106.24.210   <none>        8080:32354/TCP,9000:30956/TCP   26s
aledbf@me:~$ grpcurl --plaintext $(minikube ip):32354 yages.Echo.Ping
{
  "text": "pong"
}
aledbf@me:~$ kubectl get pods
NAME                       READY     STATUS    RESTARTS   AGE
kruiser-7f9755cfb8-56v68   2/2       Running   0          1m
aledbf@me:~$ kubectl logs kruiser-7f9755cfb8-56v68  -c proxy
172.17.0.1 - - [28/Mar/2018:12:58:58 +0000] "POST /yages.Echo/Ping HTTP/2.0" 200 11 "-" "grpc-go/1.12.0-dev"
172.17.0.1 - - [28/Mar/2018:12:58:58 +0000] "POST /grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo HTTP/2.0" 200 193 "-" "grpc-go/1.12.0-dev"
```